### PR TITLE
Fixes equals in Tuple

### DIFF
--- a/fpinjava-parent/fpinjava-common/src/main/java/com/fpinjava/common/Tuple.java
+++ b/fpinjava-parent/fpinjava-common/src/main/java/com/fpinjava/common/Tuple.java
@@ -3,16 +3,16 @@ package com.fpinjava.common;
 import java.util.Objects;
 
 
-public class Tuple<T, U> {
+public final class Tuple<T, U> {
 
-	public final T _1;
-	public final U _2;
+  public final T _1;
+  public final U _2;
 
-	public Tuple(T t, U u) {
-		this._1 = Objects.requireNonNull(t);
-		this._2 = Objects.requireNonNull(u);
-	}
-	
+  public Tuple(T t, U u) {
+    this._1 = Objects.requireNonNull(t);
+    this._2 = Objects.requireNonNull(u);
+  }
+
   @Override
   public String toString() {
     return String.format("(%s,%s)", _1,  _2);
@@ -20,11 +20,11 @@ public class Tuple<T, U> {
   
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof Tuple3))
+    if (!(o instanceof Tuple))
       return false;
     else {
       @SuppressWarnings("rawtypes")
-      Tuple3 that = (Tuple3) o;
+      Tuple that = (Tuple) o;
       return _1.equals(that._1) && _2.equals(that._2);
     }
   }

--- a/fpinjava-parent/fpinjava-common/src/main/java/com/fpinjava/common/Tuple3.java
+++ b/fpinjava-parent/fpinjava-common/src/main/java/com/fpinjava/common/Tuple3.java
@@ -3,17 +3,17 @@ package com.fpinjava.common;
 import java.util.Objects;
 
 
-public class Tuple3<T, U, V> {
+public final class Tuple3<T, U, V> {
 
-	public final T _1;
+  public final T _1;
   public final U _2;
   public final V _3;
 
-	public Tuple3(T t, U u, V v) {
-		this._1 = Objects.requireNonNull(t);
+  public Tuple3(T t, U u, V v) {
+    this._1 = Objects.requireNonNull(t);
     this._2 = Objects.requireNonNull(u);
     this._3 = Objects.requireNonNull(v);
-	}
+  }
 	
   @Override
   public String toString() {


### PR DESCRIPTION
Tuple used Tuple3 in equals for comparison. 

In Addition, because Tuples are value types, Tuple and Tuple3 are now final. This is more in line with the usage of the instanceof within equals, for further info see conclusion in [1]

I also suggest renaming Tuple to Tuple2 to be consistent with Tuple3 and the "math-speak" of n-tuple.

[1] http://www.angelikalanger.com/Articles/JavaSolutions/SecretsOfEquals/Equals.html